### PR TITLE
Add quit function to Redis Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-point/cache-js",
-  "version": "1.0.1-3",
+  "version": "1.0.1-3-test",
   "description": "A cache service for JS.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -22,6 +22,7 @@
   ],
   "scripts": {
     "build": "node_modules/.bin/tsc",
+    "watch": "tsc --watch",
     "lint": "node_modules/.bin/eslint 'src/**/*.{ts,tsx}'",
     "lint:fix": "npm run lint -- --fix",
     "test": "node_modules/.bin/jest --watch",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-point/cache-js",
-  "version": "1.0.1-3-test",
+  "version": "1.0.1-4",
   "description": "A cache service for JS.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/services/Redis.ts
+++ b/src/services/Redis.ts
@@ -60,6 +60,9 @@ class Redis implements Service {
         await this.commands.del(key);
     }
 
+    /**
+     * Quits the RedisClient.
+     */
     public async quit() {
         this.client.quit();
     }

--- a/src/services/Redis.ts
+++ b/src/services/Redis.ts
@@ -59,6 +59,10 @@ class Redis implements Service {
     public async remove(key: string): Promise<void> {
         await this.commands.del(key);
     }
+
+    public async quit() {
+        this.client.quit();
+    }
 }
 
 export default Redis;


### PR DESCRIPTION
I need to be able to quit the redis client from arch2-lambda to prevent endpoints from hanging for https://podpoint.atlassian.net/browse/SWP-1167.